### PR TITLE
Fix hashing of "time.Time" when "UseStringer" is enabled

### DIFF
--- a/hashstructure.go
+++ b/hashstructure.go
@@ -329,7 +329,11 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 				}
 
 				// if string is set, use the string value
-				if tag == "string" || w.stringer {
+				switch {
+				case w.stringer && innerV.Type() == timeType:
+					// We treat the timeType as a binary to ensure the hash with be identical regardless of
+					// if the time contains a monotonic clock or not.
+				case w.stringer || tag == "string":
 					if impl, ok := innerV.Interface().(fmt.Stringer); ok {
 						innerV = reflect.ValueOf(impl.String())
 					} else if tag == "string" {

--- a/hashstructure.go
+++ b/hashstructure.go
@@ -329,11 +329,9 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 				}
 
 				// if string is set, use the string value
-				switch {
-				case w.stringer && innerV.Type() == timeType:
-					// We treat the timeType as a binary to ensure the hash with be identical regardless of
-					// if the time contains a monotonic clock or not.
-				case w.stringer || tag == "string":
+				// We treat the timeType as a binary to ensure the hash with be identical regardless of
+				// if the time contains a monotonic clock or not.
+				if (w.stringer || tag == "string") && innerV.Type() != timeType {
 					if impl, ok := innerV.Interface().(fmt.Stringer); ok {
 						innerV = reflect.ValueOf(impl.String())
 					} else if tag == "string" {

--- a/hashstructure_test.go
+++ b/hashstructure_test.go
@@ -180,6 +180,20 @@ func TestHash_equal(t *testing.T) {
 			},
 			true,
 		},
+		{
+			struct {
+				Foo time.Time `hash:"string"`
+			}{
+				Foo: now, // contains monotonic clock
+			},
+			struct {
+				Foo time.Time `hash:"string"`
+			}{
+				time.Date(now.Year(), now.Month(), now.Day(), now.Hour(),
+					now.Minute(), now.Second(), now.Nanosecond(), now.Location()), // does not contain monotonic clock
+			},
+			true,
+		},
 	}
 
 	for i, tc := range cases {
@@ -207,137 +221,15 @@ func TestHash_equal(t *testing.T) {
 				t.Fatalf("bad, expected: %#v\n\n%#v\n\n%#v", tc.Match, tc.One, tc.Two)
 			}
 		})
-	}
-}
-
-func TestHash_equalUseStringer(t *testing.T) {
-	type testFoo struct{ Name string }
-	type testBar struct{ Name string }
-
-	now := time.Now()
-
-	cases := []struct {
-		One, Two interface{}
-		Match    bool
-	}{
-		{
-			map[string]string{"foo": "bar"},
-			map[interface{}]string{"foo": "bar"},
-			true,
-		},
-
-		{
-			map[string]interface{}{"1": "1"},
-			map[string]interface{}{"1": "1", "2": "2"},
-			false,
-		},
-
-		{
-			struct{ Fname, Lname string }{"foo", "bar"},
-			struct{ Fname, Lname string }{"bar", "foo"},
-			false,
-		},
-
-		{
-			struct{ Lname, Fname string }{"foo", "bar"},
-			struct{ Fname, Lname string }{"foo", "bar"},
-			false,
-		},
-
-		{
-			struct{ Lname, Fname string }{"foo", "bar"},
-			struct{ Fname, Lname string }{"bar", "foo"},
-			false,
-		},
-
-		{
-			testFoo{"foo"},
-			testBar{"foo"},
-			false,
-		},
-
-		{
-			struct {
-				Foo        string
-				unexported string
-			}{
-				Foo:        "bar",
-				unexported: "baz",
-			},
-			struct {
-				Foo        string
-				unexported string
-			}{
-				Foo:        "bar",
-				unexported: "bang",
-			},
-			true,
-		},
-
-		{
-			struct {
-				testFoo
-				Foo string
-			}{
-				Foo:     "bar",
-				testFoo: testFoo{Name: "baz"},
-			},
-			struct {
-				testFoo
-				Foo string
-			}{
-				Foo: "bar",
-			},
-			true,
-		},
-
-		{
-			struct {
-				Foo string
-			}{
-				Foo: "bar",
-			},
-			struct {
-				testFoo
-				Foo string
-			}{
-				Foo: "bar",
-			},
-			true,
-		},
-		{
-			now, // contains monotonic clock
-			time.Date(now.Year(), now.Month(), now.Day(), now.Hour(),
-				now.Minute(), now.Second(), now.Nanosecond(), now.Location()), // does not contain monotonic clock
-			true,
-		},
-		{
-			struct {
-				Foo time.Time
-			}{
-				Foo: now, // contains monotonic clock
-			},
-			struct {
-				Foo time.Time
-			}{
-				time.Date(now.Year(), now.Month(), now.Day(), now.Hour(),
-					now.Minute(), now.Second(), now.Nanosecond(), now.Location()), // does not contain monotonic clock
-			},
-			true,
-		},
-	}
-
-	options := HashOptions{UseStringer: true}
-	for i, tc := range cases {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%d_UseStringer", i), func(t *testing.T) {
 			t.Logf("Hashing: %#v", tc.One)
-			one, err := Hash(tc.One, testFormat, &options)
+			one, err := Hash(tc.One, testFormat, &HashOptions{UseStringer: true})
 			t.Logf("Result: %d", one)
 			if err != nil {
 				t.Fatalf("Failed to hash %#v: %s", tc.One, err)
 			}
 			t.Logf("Hashing: %#v", tc.Two)
-			two, err := Hash(tc.Two, testFormat, nil)
+			two, err := Hash(tc.Two, testFormat, &HashOptions{UseStringer: true})
 			t.Logf("Result: %d", two)
 			if err != nil {
 				t.Fatalf("Failed to hash %#v: %s", tc.Two, err)


### PR DESCRIPTION
**Problem:**

When using the `UseStringer: true` option with a struct containing a field of type `time.Time`, then the hash become architecture depedent due to the `String()` method of `time.Time` using the monotonic clock.

**Suggested Solution:**

Hash `time.Time` as binary (expanding the existing fix in the `hashstructure` repository to also struct fields of type `time.Time`)

**Verification:**

I added a couple of tests that reproduce the problem and verify the suggested solution.